### PR TITLE
method correction get_message

### DIFF
--- a/src/RabbitMq.py
+++ b/src/RabbitMq.py
@@ -1102,7 +1102,7 @@ class RabbitMq(object):
         | 1 | {u'payload': u'message body 1', u'exchange': u'testExchange', u'routing_key': u'testQueue', u'payload_bytes': 14, u'message_count': 3, u'payload_encoding': u'string', u'redelivered': False, u'properties': []} |
         | ... |
         """
-        path = '/queues/{vhost}/{name}/get'.format(
+        path = '/queues/{vhost}/{name}'.format(
             vhost=self._quote_vhost(vhost), name=quote(queue_name))
         body = {"count": count, "requeue": requeue, "encoding": encoding}
         if truncate is not None:


### PR DESCRIPTION
Default get methods in rabbit do not have the "get" at the end

before: http://172.0.0.00:15672/api/queues/%2F/queueName/get

correct:  http://172.0.0.00:15672/api/queues/%2F/queueName
